### PR TITLE
Revert "chore(deps): update dependency m2r2 to v0.3.3.post2"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==3.2.1
 sphinx-rtd-theme==0.5.2
 sphinx-fakeinv==1.0.0
-m2r2==0.3.3.post2
+m2r2==0.2.5


### PR DESCRIPTION
Reverts matfax/mutapath#292 because latest sphinx_rtd_theme doesn't support docutils 0.19 yet.