### PR TITLE
chore(deps): update to latest compatible path version >=16.2, <=16.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
         name: install dependencies with extra ${{ matrix.extras }}
         uses: allanchain/poetry-cache-action@54a8477b640e34d95162dfe42d291c1c3f439adc
         with:
+          cache-key-prefix: poetry-${{ matrix.extras }}
           ensure-module: green
           install-args: -n -vv -E ${{ matrix.extras }}
       - name: running tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         poetry-version: [1.5.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        extras: ['', '-E mashumaro']
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -36,10 +37,10 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ matrix.poetry-version }}
-      - uses: allanchain/poetry-cache-action@release
+      - uses: allanchain/poetry-cache-action@230f759485b96b4186f5210c3a24d9d0351f5a6a
         with:
           ensure-module: green
-          install-args: -n -vv
+          install-args: -n -vv ${{ matrix.extras }}
       - name: running tests
         run: poetry run green -vv
       - name: building

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,12 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
         poetry-version: [1.5.1]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        extras: ['', '-E mashumaro']
+        extras: ['', 'mashumaro']
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
-    name: python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: 'python ${{ matrix.python-version }} on ${{ matrix.os }} [${{ matrix.extras }}]'
     steps:
       - uses: actions/checkout@v3.5.3
       - name: setting up python ${{ matrix.python-version }}
@@ -37,10 +37,18 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ matrix.poetry-version }}
-      - uses: allanchain/poetry-cache-action@230f759485b96b4186f5210c3a24d9d0351f5a6a
+      - if: matrix.extras == ''
+        name: install dependencies without extras
+        uses: allanchain/poetry-cache-action@54a8477b640e34d95162dfe42d291c1c3f439adc
         with:
           ensure-module: green
-          install-args: -n -vv ${{ matrix.extras }}
+          install-args: -n -vv
+      - if: matrix.extras != ''
+        name: install dependencies with extra ${{ matrix.extras }}
+        uses: allanchain/poetry-cache-action@54a8477b640e34d95162dfe42d291c1c3f439adc
+        with:
+          ensure-module: green
+          install-args: -n -vv -E ${{ matrix.extras }}
       - name: running tests
         run: poetry run green -vv
       - name: building

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,8 @@ jobs:
         uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ matrix.poetry-version }}
-      - uses: allanchain/poetry-cache-action@release
-        with:
-          ensure-module: green
-          install-args: -n -vv
+      - name: install dependencies
+        run: poetry install -n -vv --all-extras
       - name: running tests
         run: poetry run green -vv
       - name: install poetry git version plugin

--- a/mutapath/immutapath.py
+++ b/mutapath/immutapath.py
@@ -13,7 +13,7 @@ from typing import Union, Iterable, Callable, Optional
 
 import filelock
 import path
-from path import multimethod
+from path.classes import multimethod
 from cached_property import cached_property
 from filelock import SoftFileLock
 
@@ -204,7 +204,7 @@ class Path(SerializableType):
         self._contained.__exit__()
 
     def __fspath__(self):
-        return self._contained.__fspath__()
+        return os.fspath(self._contained)
 
     def __invert__(self):
         """Create a cloned :class:`~mutapath.MutaPath` from this immutable Path."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -637,7 +637,7 @@ files = [
 name = "mashumaro"
 version = "3.8.1"
 description = "Fast serialization library on top of dataclasses"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "mashumaro-3.8.1-py3-none-any.whl", hash = "sha256:e060469a4bec1c86f8145ea27ecd99027ea3e343075a4efcb5e8a969a45b9fb9"},
@@ -688,18 +688,18 @@ files = [
 
 [[package]]
 name = "path"
-version = "15.1.2"
+version = "16.7.1"
 description = "A module wrapper for os.path"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "path-15.1.2-py3-none-any.whl", hash = "sha256:e07601c83ae394cb05298c96e073c251d185599ecbf3cf7110b00f4d1898d53e"},
-    {file = "path-15.1.2.tar.gz", hash = "sha256:bb629aefd86825bf21c8bcfa0f8691a6e5abdc3e43d50b626fe6aac5b13f60b7"},
+    {file = "path-16.7.1-py3-none-any.whl", hash = "sha256:57f6ac8209c2b8fd3c515cf013e3b288af43460dddacf1d0249839aabcc14517"},
+    {file = "path-16.7.1.tar.gz", hash = "sha256:2b477f5887033f3cbea1cfd8553ee6a6a498eb2540a19f4aa082822aadcea30a"},
 ]
 
 [package.extras]
-docs = ["jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["appdirs", "packaging", "pygments", "pytest (>=3.5,!=3.7.3)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=1.2.3)", "pytest-cov", "pytest-enabler", "pytest-flake8", "pytest-mypy"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["appdirs", "packaging", "pygments", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "pywin32"]
 
 [[package]]
 name = "pathspec"
@@ -1136,7 +1136,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+mashumaro = ["mashumaro"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "d9bc231774318f5eac02d3ca088e6e43310d02e8f0c94cd552e6597f24175aae"
+content-hash = "a79ad9e7f6c7ae4162c636701163515e3ccceaf88d1994ef2283d450375f2678"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = ["matfax <mat@fax.fyi>"]
 license = "lgpl-3.0"
 keywords = ["pathlib", "mutable", "path"]
 repository = "https://github.com/matfax/mutapath"
-homepage = "https://github.com/matfax/mutapath"
-documentation = "https://mutapath.readthedocs.io/en/latest/"
+homepage = "https://mutapath.fax.fyi"
+documentation = "https://mutapath.fax.fyi"
 readme = "README.md"
 
 [tool.poetry.dependencies]
@@ -15,13 +15,16 @@ python = "^3.8"
 singletons = "~0.2.5"
 cached-property = "~1.5.2"
 filelock = "~3.12.2"
-path = ">=14,<=16.6.0"
+path = ">=16.2,<=16.7.1"
+mashumaro = {version = ">=3,<=3.8.1", optional = true}
+
+[tool.poetry.extras]
+mashumaro = ["mashumaro"]
 
 [tool.poetry.dev-dependencies]
 green = "~3.4.3"
 coverage = "~7.2.7"
 codecov = "~2.1.13"
-mashumaro = "~3.8.1"
 bandit = "~1.7.5"
 black = "~23.7.0"
 

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -1,16 +1,23 @@
+import unittest
 from dataclasses import dataclass
 
-from mashumaro import DataClassDictMixin
+try:
+    from mashumaro import DataClassDictMixin
+    import_success = True
+except ImportError:
+    import_success = False
 
 from mutapath import Path
 from tests.helper import PathTest
 
 
-@dataclass
-class DataClass(DataClassDictMixin):
-    path: Path = Path()
+if import_success:
+    @dataclass
+    class DataClass(DataClassDictMixin):
+        path: Path = Path()
 
 
+@unittest.skipIf(not import_success, "mashumaro extra is not installed")
 class TestSerialization(PathTest):
     def test_empty_serialization(self):
         expected = {"path": ""}

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 try:
     from mashumaro import DataClassDictMixin
+
     import_success = True
 except ImportError:
     import_success = False
@@ -12,6 +13,7 @@ from tests.helper import PathTest
 
 
 if import_success:
+
     @dataclass
     class DataClass(DataClassDictMixin):
         path: Path = Path()


### PR DESCRIPTION
- Updated locked dependencies in poetry.lock file.
- Added extra dependency 'mashumaro' to the extras section in pyproject.toml.
- Updated install arguments for allanchain/poetry-cache-action in build.yml.
- Modified import statement in immutapath.py to use path.classes module instead of path module.
- Updated homepage and documentation URLs in pyproject.toml.
- Added new step to install dependencies using poetry command in publish.yml.
- Added a new test case for importing mashumaro package conditionally based on successful import.

Closes #312