### PR TITLE
chore: delete issue label bot config

### DIFF
--- a/.github/issue_label_bot.yaml
+++ b/.github/issue_label_bot.yaml
@@ -1,4 +1,0 @@
-label-alias:
-  bug: 'bug'
-  feature_request: 'enhancement'
-  question: 'question'


### PR DESCRIPTION
The Issue Label Bot is no longer active, this cleans up its config.