### PR TITLE
ci(audit): hide outdated auditing comments

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,10 @@ on:
       - '**/pyproject.toml'
       - '.github/workflows/audit.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     permissions:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,6 +22,9 @@ jobs:
         shell: bash
     name: audit dependencies
     steps:
+      - uses: int128/hide-comment-action@v1.23.0
+        with:
+          contains: Packj Audit Report
       - uses: actions/checkout@v3.5.3
       - name: setting up python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.6.1


### PR DESCRIPTION
This avoids the duplicate comment spam from the PR audit.