### PR TITLE
ci: migrate from renovatebot to dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    labels:
+      - chore
+      - github_actions
+    schedule:
+      interval: daily


### PR DESCRIPTION
Renovate Bot has issues with pinned github actions from branches, and even with unpinned tags sometimes.